### PR TITLE
Changed Platypus container to host new VMware API Explorer as the UI.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ui"]
-	path = ui
-	url = https://github.com/swagger-api/swagger-ui.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,17 +20,13 @@ COPY ./logo_small.png /usr/share/nginx/html/images/logo_small.png
 # and then uninstall python. done as one step so that image size is not bloated with python 
 # which is unused except for the config step.  To pickup a new version, update the VERSION
 # env var below to match the release in github 
-RUN export VERSION="0.0.2" && \
-    apk add --update python && \
-    apk update && \
-    apk add ca-certificates && \
-    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-dist-${VERSION}.zip && \
-    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-tools-${VERSION}.zip && \
-    unzip -o api-explorer-dist-*.zip  && \
-    unzip -o api-explorer-tools-*.zip  && \
-    python apiFilesToLocalJson.py --swaggerglob /usr/share/nginx/html/local/swagger/*.json --outfile /usr/share/nginx/html/local.json && \
-    rm apiFilesToLocalJson.py && \
-    rm api-explorer*.zip && \
+RUN export VER="0.0.2" && \
+    apk add --update python ca-certificates && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VER}/api-explorer-dist-${VER}.zip && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VER}/api-explorer-tools-${VER}.zip && \
+    unzip -o api-explorer-dist-${VER}.zip && unzip -o api-explorer-tools-${VER}.zip  && \
+    python apiFilesToLocalJson.py --swaggerglob ./local/swagger/*.json --outfile ./local.json && \
+    rm apiFilesToLocalJson.py  api-explorer*.zip && \
     apk del python ca-certificates && \
     rm -rf /var/cache/apk/* 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Docker build file for VMware Platypus kAPI explorer/Platypus container build
-
+# Docker build file for VMware Platypus API explorer container build
 FROM alpine:3.3
 
 MAINTAINER Roman Tarnavski, Aaron Spear
@@ -15,7 +14,6 @@ COPY ./api*.json /usr/share/nginx/html/local/swagger/
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY "runner.sh" /usr/share/nginx/html/
-<<<<<<< HEAD
 COPY ./logo_small.png /usr/share/nginx/html/images/logo_small.png
 
 # install python, certificates so that wget works, download the distribution, configure it,
@@ -36,27 +34,5 @@ RUN export VERSION="0.0.2" && \
     apk del python ca-certificates && \
     rm -rf /var/cache/apk/* 
 
-=======
-
-# install python, certificates so that wget works, download the distribution, configure it,
-# and then uninstall python. done as one step so that image size is not bloated with python 
-# which is unused except for the config step.  To pickup a new version, update the VERSION
-# env var below to match the release in github 
-RUN export VERSION="0.0.2" && \
-    apk add --update python && \
-    apk update && \
-    apk add ca-certificates && \
-    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-dist-${VERSION}.zip && \
-    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-tools-${VERSION}.zip && \
-    unzip -o api-explorer-dist-*.zip  && \
-    unzip -o api-explorer-tools-*.zip  && \
-    python apiFilesToLocalJson.py --swaggerglob /usr/share/nginx/html/local/swagger/*.json --outfile /usr/share/nginx/html/local.json && \
-    rm apiFilesToLocalJson.py && \
-    rm api-explorer*.zip && \
-    apk del python ca-certificates && \
-    rm -rvf /var/cache/apk/* && \
-    ls -alR  
-
->>>>>>> aa5169c... Changed Platypus container to host new VMware API Explorer as the UI.
 EXPOSE 80
 ENTRYPOINT ["/usr/share/nginx/html/runner.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,62 @@
-#
-# used for Project Platypus; for the make benefit
-# of VMware API's Documentation using Swagger
-#
-# as seen on http://github.com/vmware/platypus
-# 
-
-#
-# hacky way of injecting the API definition
-#
+# Docker build file for VMware Platypus kAPI explorer/Platypus container build
 
 FROM alpine:3.3
 
-MAINTAINER Roman Tarnavski
+MAINTAINER Roman Tarnavski, Aaron Spear
 
-RUN apk add --update sed nginx
+# need nginx web server.  
+RUN apk add --update nginx 
 
 WORKDIR /usr/share/nginx/html/
 
-ADD ./ui/dist/ /usr/share/nginx/html
+# copy the local swagger json files into the image.  All files in this location are scanned
+# and included in the 'local' API list in API Explorer
+COPY ./api*.json /usr/share/nginx/html/local/swagger/
 
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY "runner.sh" /usr/share/nginx/html/
+<<<<<<< HEAD
 COPY ./logo_small.png /usr/share/nginx/html/images/logo_small.png
 
+# install python, certificates so that wget works, download the distribution, configure it,
+# and then uninstall python. done as one step so that image size is not bloated with python 
+# which is unused except for the config step.  To pickup a new version, update the VERSION
+# env var below to match the release in github 
+RUN export VERSION="0.0.2" && \
+    apk add --update python && \
+    apk update && \
+    apk add ca-certificates && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-dist-${VERSION}.zip && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-tools-${VERSION}.zip && \
+    unzip -o api-explorer-dist-*.zip  && \
+    unzip -o api-explorer-tools-*.zip  && \
+    python apiFilesToLocalJson.py --swaggerglob /usr/share/nginx/html/local/swagger/*.json --outfile /usr/share/nginx/html/local.json && \
+    rm apiFilesToLocalJson.py && \
+    rm api-explorer*.zip && \
+    apk del python ca-certificates && \
+    rm -rf /var/cache/apk/* 
+
+=======
+
+# install python, certificates so that wget works, download the distribution, configure it,
+# and then uninstall python. done as one step so that image size is not bloated with python 
+# which is unused except for the config step.  To pickup a new version, update the VERSION
+# env var below to match the release in github 
+RUN export VERSION="0.0.2" && \
+    apk add --update python && \
+    apk update && \
+    apk add ca-certificates && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-dist-${VERSION}.zip && \
+    wget https://github.com/vmware/api-explorer/releases/download/${VERSION}/api-explorer-tools-${VERSION}.zip && \
+    unzip -o api-explorer-dist-*.zip  && \
+    unzip -o api-explorer-tools-*.zip  && \
+    python apiFilesToLocalJson.py --swaggerglob /usr/share/nginx/html/local/swagger/*.json --outfile /usr/share/nginx/html/local.json && \
+    rm apiFilesToLocalJson.py && \
+    rm api-explorer*.zip && \
+    apk del python ca-certificates && \
+    rm -rvf /var/cache/apk/* && \
+    ls -alR  
+
+>>>>>>> aa5169c... Changed Platypus container to host new VMware API Explorer as the UI.
 EXPOSE 80
-
-COPY "api-*.json" /usr/share/nginx/html/
-
-COPY "runner.sh" /usr/share/nginx/html/
-
 ENTRYPOINT ["/usr/share/nginx/html/runner.sh"]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 Platypus is an initiative to improve documentation across a number of VMware's products (see [Supported Products](#supported-products)) as described using [Open API](https://openapis.org/) and displaying these local APIs using [VMware's API Explorer component](http://github.com/vmware/api-explorer/). Open API definitions as declared in the root of the project are displayed as 'local' definitions in the API Explorer.  API Explorer can also display official API definitions provided by VMware at https://code.vmware.com/apis.
 
 ## Just Run it
+There are nightly builds that publish to Dockerhub that you should be able to just use.  The command below will run the container on your host at port 8080 (you can change this port to whatever works for you.  Can be port 80 as well.)
 
-`docker run --rm --name platypus -p 80:80 vmware/platypus2`
+`docker run --rm --name platypus -p 8080:80 vmware/platypus`
+
+This 
 
 ## Migrating from previous versions of Platypus
 Previously Platypus required specifying which API you wanted to access in the Swagger UI, and only allowed

--- a/README.md
+++ b/README.md
@@ -1,36 +1,17 @@
 ## Project Platypus
 ![](platypus.jpg)
 
-Platypus is an initiative to improve documentation across a number of VMware's products (see [Supported Products](#supported-products)) as described using [Open API](https://openapis.org/) and [Swagger UI](http://swagger.io/swagger-ui/). This allows everyone to easily consume, and enhance VMware's REST API's & their usage.
+Platypus is an initiative to improve documentation across a number of VMware's products (see [Supported Products](#supported-products)) as described using [Open API](https://openapis.org/) and displaying these local APIs using [VMware's API Explorer component](http://github.com/vmware/api-explorer/). Open API definitions as declared in the root of the project are displayed as 'local' definitions in the API Explorer.  API Explorer can also display official API definitions provided by VMware at https://code.vmware.com/apis.
 
 ## Just Run it
 
-`docker run --rm --name platypus -p 80:80 vmware/platypus`
+`docker run --rm --name platypus -p 80:80 vmware/platypus2`
 
-## Specify PRODUCT & VERSION
+## Migrating from previous versions of Platypus
+Previously Platypus required specifying which API you wanted to access in the Swagger UI, and only allowed
+using one API at a time.  In this new version all APIs are provided simultaneously with no change to the container.  
 
-`docker run --name platypus --rm -p 80:80 -e PRODUCT="vra" -e VERSION="7" vmware/platypus`
-
-> replace vRA and version with product of your choice
-
-## Supported Products
-
-| Product       | Version       | Build   |
-| ------------- | :---:         | :---:   |
-| vRA           | 7             | 3311738 |
-| vROPs         | 6.2           | 3445568 |
-| vRLI          | 3.3           | 3571626 |
-| vRO           | 7             | 3310032 |
-| NSX			| 6.2		    | 2986609 |
-
-
-_**or**_
-
-#### Get it
-
-clone this repo, and then:
-
-`git submodule update --init --recursive` to make sure you obtain the Swagger-UI code-base
+If you wish to see only the APIs provided in the Platypus container, click on the 'local' checkbox at the bottom left corner of the page.  If you also wish to see all VMware official API documents that are currently hosted on the BETA https://code.vmware.com/apis site, you can also click 'remote'
 
 #### Build and run
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ There are nightly builds that publish to Dockerhub that you should be able to ju
 
 `docker run --rm --name platypus -p 8080:80 vmware/platypus`
 
-This 
-
 ## Migrating from previous versions of Platypus
 Previously Platypus required specifying which API you wanted to access in the Swagger UI, and only allowed
 using one API at a time.  In this new version all APIs are provided simultaneously with no change to the container.  

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,122 @@
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        #charset koi8-r;
+
+        #access_log  logs/host.access.log  main;
+
+        location / {
+            add_header 'Access-Control-Allow-Origin' *;
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Mx-ReqToken,X-Requested-With';
+
+            root   html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # another virtual host using mix of IP-, name-, and port-based configuration
+    #
+    #server {
+    #    listen       8000;
+    #    listen       somename:8080;
+    #    server_name  somename  alias  another.alias;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443 ssl;
+    #    server_name  localhost;
+
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    ssl_session_cache    shared:SSL:1m;
+    #    ssl_session_timeout  5m;
+
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers  on;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+}

--- a/runner.sh
+++ b/runner.sh
@@ -1,36 +1,4 @@
 #!/bin/sh
 
-echo "specifying your environment .. "
-
-if [ -z ${PRODUCT} ]; then
-  echo "PRODUCT not set, defaulting to vRA"
-  export PRODUCT="vra"
-fi
-
-if [ -z ${VERSION} ]; then
-  echo "VERSION not set, defaulting to 7"
-  export VERSION="7"
-fi
-
-if [ -z ${API_HOST} ]; then
-  echo "API_HOST not set, defaulting to localhost."
-  export API_HOST="localhost"
-fi
-
-# check the file actually exists
-API_FILE="api-$PRODUCT-$VERSION.json"
-
-if [ ! -f $API_FILE ]; then
-  echo "API Definition [ $API_FILE ] not found. Aborting"
-  exit 1
-fi
-
-sed -i -e "s|http://petstore.swagger.io/v2/swagger.json|api-$PRODUCT-$VERSION.json|g" index.html
-sed -i -e "s|platypus_host|$API_HOST|g" api-$PRODUCT-$VERSION.json
-sed -i -e 's,http://swagger.io,https://github.com/vmware/platypus,g' index.html
-sed -i -e 's,>swagger<,>platypus<,g' index.html
-sed -i -e 's,89bf04,01BFBF,g' ./css/screen.css
-sed -i -e 's,20px 0 20px 40px;,20px 0 20px 60px;,g' ./css/screen.css
-
-echo "starting your swaggerness"
+echo "Starting Platypus API Explorer"
 nginx -g 'daemon off;'


### PR DESCRIPTION
This revision changes the Docker build of the Platypus container so that it
uses the first release of the newly open sourced VMware API Explorer web
component.  The API Explorer provides the ability to browse all Platypus
provided Swagger/Open API docs as well as API docs coming from VMware's
new API services that are in beta at https://code.vmware.com/apis .  The
API explorer provides access to related docs, SDKs, sample code and more as
well.

Note that the features to couple API definitions to related resources does
require some metadata/tags that are missing in the current implementation
in this revision, but these features can be added.

ARCHITECTURE:  What the Dockerfile build now does is a couple of steps:
1) download the current release from https://github.com/vmware/api-explorer
2) extract the built web image
3) use a python based tool to iterate the Platypus included swagger.json
   files and generate a "local.json" metadata file that the API Explorer
   component uses to know what APIs to display.
4) create a minimal size and footprint web container exactly as before.

This revision no longer depends directly on the upstream Swagger UI, but
rather uses it via the API Explorer.

Signed-off-by: Aaron Spear <aspear@vmware.com>