### PR TITLE
Updating all consumers of API Explorer to version 0.0.35.  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ADD ./favicons.tar.gz /usr/share/nginx/html/
 # and then uninstall python. done as one step so that image size is not bloated with python 
 # which is unused except for the config step.  To pickup a new version, update the VERSION
 # env var below to match the release in github 
-RUN export VER="0.0.29" && \
+RUN export VER="0.0.35" && \
     apk add --update ca-certificates && \
     wget https://github.com/vmware/api-explorer/releases/download/${VER}/api-explorer-dist-${VER}.zip && \
     wget https://github.com/vmware/api-explorer/releases/download/${VER}/api-explorer-tools-${VER}.zip && \


### PR DESCRIPTION
No big changes for Platypus, just a few stability and bug fixes.  This version does have support for vSphere SSO and vRA SSO though we need a few more code changes to be able to use this in Platypus.

Signed-off-by: Aaron Spear <aspear@vmware.com>