### PR TITLE
Updated to API Explorer 2.0.0a5 to pick up fixes in API Explorer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD ./favicons.tar.gz /usr/share/nginx/html/
 # which is unused except for the config step.  To pickup a new version, update the VERSION
 # env var below to match the release in github 
 
-RUN export VER="2.0.0" && export MILESTONE="a3" &&\
+RUN export VER="2.0.0" && export MILESTONE="a5" &&\
     apk add --update ca-certificates && \
     wget https://github.com/vmware/api-explorer/releases/download/${VER}${MILESTONE}/api-explorer-dist-${VER}.zip && \
     wget https://github.com/vmware/api-explorer/releases/download/${VER}${MILESTONE}/api-explorer-tools-${VER}.zip && \

--- a/apix-config.json
+++ b/apix-config.json
@@ -2,6 +2,7 @@
     "useHash": true,
     "base" : "/",
     "path" : "",
+    "title": "VMware API Explorer",
     "apiListHeaderText" : "Available APIs",
     "remoteApiUrl" : "https://apigw.vmware.com/v1/m4/api/dcr/rest/apix",
     "remoteSampleExchangeUrl" : "https://apigw.vmware.com/sampleExchange/v1",
@@ -22,5 +23,6 @@
     "hideLanguagesFilter" : false,
     "hideSourcesFilter" : false,
     "hidePreference" : false,
+    "hideApiInfo" : false,
     "sso" : []
 }


### PR DESCRIPTION
Picking up minor fixes including updating to the new VMware API Gateway URL.